### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/esmevane/serde-request-envelope/compare/v0.1.1...v0.1.2) - 2024-12-17
+
+### Added
+
+- expose type name fn (#2)
+
 ## [0.1.1](https://github.com/esmevane/serde-request-envelope/compare/v0.1.0...v0.1.1) - 2024-12-14
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-request-envelope"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "A serde request envelope with named type and data fields."


### PR DESCRIPTION
## 🤖 New release
* `serde-request-envelope`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/esmevane/serde-request-envelope/compare/v0.1.1...v0.1.2) - 2024-12-17

### Added

- expose type name fn (#2)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).